### PR TITLE
Add short-form params for case sensitivity

### DIFF
--- a/src/passgen.py
+++ b/src/passgen.py
@@ -213,10 +213,10 @@ def main():
                              help="don't use letters",
                              action='store_false', dest='letters')
     case_group = parser.add_mutually_exclusive_group()
-    case_group.add_argument("--upper",
+    case_group.add_argument("-C", "--upper",
                             help="use only upper case letters",
                             action='store_true')
-    case_group.add_argument("--lower",
+    case_group.add_argument("-c", "--lower",
                             help="use only lower case letters",
                             action='store_true')
     args = parser.parse_args()


### PR DESCRIPTION
Closes #4

- [x] All tests pass successfully
- [x] Running from Python returns random passwords
- [x] New flag work as expected:
```
$ python src/passgen.py -C
src/passgen.py:168: DeprecationWarning: The *random* parameter to shuffle() has been deprecated
since Python 3.9 and will be removed in a subsequent version.
  srandom.shuffle(chars, srandom)
X0PT08VES1NG
8LU9N89BHVYK
477WYY8EUWUV
893W556Z94L5
57P4D9K98Q8U
1ZSOIY904WKX
7X05AKQT7K2J
404YY01X75LM
MBUG7IW2BC76
OC5DAPKD70KT
(venv)
$ python src/passgen.py -c
src/passgen.py:168: DeprecationWarning: The *random* parameter to shuffle() has been deprecated
since Python 3.9 and will be removed in a subsequent version.
  srandom.shuffle(chars, srandom)
h1l8c7c37u16
2fb92m10cql3
2rt06asr44w4
6k8q9g6pb6je
7q415ntein40
e00k19m5n4gr
511fcnwyf2xv
u66ygnk621v7
399e2224rxy9
4knp68471i5b
(venv)
```